### PR TITLE
🚀 feat(Makefile): add automated tag and release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,63 +335,46 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: [examples, documentation, test, lint, security]
+    permissions:
+      pages: write
+      id-token: write
     
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-    - name: Download all artifacts
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+    - name: Set up Go
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
 
-    - name: Create release packages
+    - name: Cache Go modules
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ env.GO_VERSION }}-
+
+    - name: Create release packages using Makefile
+      env:
+        VERSION: ${{ github.ref_name }}
+        LLAMA_CPP_BUILD: ${{ env.LLAMA_CPP_BUILD }}
       run: |
-        mkdir -p dist
-        
-        # Extract version from tag
-        VERSION=${GITHUB_REF#refs/tags/v}
-        
-        # Package each platform
-        for platform in linux darwin windows; do
-          for arch in amd64 arm64; do
-            # Skip unsupported combinations
-            if [[ "$platform" == "windows" && "$arch" == "arm64" ]]; then
-              continue
-            fi
-            
-            echo "Packaging $platform-$arch"
-            pkg_name="gollama.cpp-v$VERSION-llamacpp.${{ env.LLAMA_CPP_BUILD }}-$platform-$arch"
-            mkdir -p "dist/$pkg_name"
-            
-            # Copy Go binaries if they exist
-            if [ -d "build-$platform-$arch" ]; then
-              cp -r build-$platform-$arch/* "dist/$pkg_name/"
-            fi
-            
-            # Copy libraries if they exist
-            if [ -d "libs-$platform-$arch" ]; then
-              cp -r libs-$platform-$arch/* "dist/$pkg_name/"
-            fi
-            
-            # Copy documentation
-            cp README.md LICENSE CHANGELOG.md "dist/$pkg_name/"
-            
-            # Create archive
-            cd dist
-            if [[ "$platform" == "windows" ]]; then
-              zip -r "$pkg_name.zip" "$pkg_name"
-            else
-              tar -czf "$pkg_name.tar.gz" "$pkg_name"
-            fi
-            rm -rf "$pkg_name"
-            cd ..
-          done
-        done
+        # Extract version from tag (remove 'v' prefix)
+        export VERSION=${VERSION#v}
+        echo "Creating release for version: $VERSION"
+        echo "Using llama.cpp build: $LLAMA_CPP_BUILD"
+        make release
 
     - name: Extract release notes
       id: extract_notes
       run: |
         # Extract release notes from CHANGELOG.md
-        VERSION=${GITHUB_REF#refs/tags/v}
+        VERSION=${{ github.ref_name }}
+        VERSION=${VERSION#v}
         sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '$d' > release_notes.md
 
     - name: Create GitHub Release
@@ -420,6 +403,30 @@ jobs:
           fi
         done
 
+    - name: Publish to Go Module Proxy
+      run: |
+        echo "Publishing module to Go module proxy..."
+        # Get the module name from go.mod
+        MODULE_NAME=$(go mod edit -json | jq -r '.Module.Path')
+        TAG_VERSION=${{ github.ref_name }}
+        
+        echo "Module: $MODULE_NAME"
+        echo "Version: $TAG_VERSION"
+        
+        # Request the module from the proxy to trigger indexing
+        echo "Requesting module from proxy.golang.org..."
+        GOPROXY=proxy.golang.org go list -m "$MODULE_NAME@$TAG_VERSION" || echo "Module may take a few minutes to be available"
+        
+        # Also try to fetch module info to ensure it's properly indexed
+        echo "Verifying module availability..."
+        curl -f "https://proxy.golang.org/$MODULE_NAME/@v/$TAG_VERSION.info" || echo "Module indexing in progress"
+        
+        echo "Go module publication requested. The module should be available at:"
+        echo "  go get $MODULE_NAME@$TAG_VERSION"
+
+    - name: Deploy to GitHub Pages
+      uses: actions/deploy-pages@v1
+
   examples:
     name: Build Examples
     runs-on: ${{ matrix.os }}
@@ -437,13 +444,6 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
 
-    - name: Download library artifacts
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-      with:
-        pattern: libs-*
-        merge-multiple: true
-        path: libs/
-
     - name: Build examples
       run: make build-examples
 
@@ -460,15 +460,16 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
 
-    - name: Generate Go documentation
-      run: |
-        go doc -all . > docs/API.md || true
-
-    - name: Deploy to GitHub Pages
+    - name: Install doc2go
+      run: go install go.abhg.dev/doc2go@latest
+    
+    - name: Generate API reference
+      run: doc2go ./...
+    
+    - name: Upload pages
       if: github.ref == 'refs/heads/main'
-      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs
+      uses: actions/upload-pages-artifact@v1
+
+
 
         


### PR DESCRIPTION
* Implemented a `tag-release` target for automated version tagging and release creation.
* Ensures the process can only be run from the `main` branch and checks for up-to-date status with the remote.
* Handles existing tags and GitHub releases, updating as necessary.
* Increments the patch version for the next development cycle after a release.