### PR TITLE
fix: align LlamaContextParams/LlamaModelParams with llama.cpp b6862 ABI

### DIFF
--- a/examples/eval-callback/main.go
+++ b/examples/eval-callback/main.go
@@ -436,7 +436,6 @@ func main() {
 	ctxParams.NBatch = 512
 	ctxParams.NSeqMax = 1
 	ctxParams.NThreads = int32(*threads)
-	ctxParams.Logits = 1
 
 	// NOTE: In a real implementation, we would set eval callbacks here:
 	// ctxParams.CbEval = callbackFunctionPointer

--- a/examples/simple-chat-with-loader/main.go
+++ b/examples/simple-chat-with-loader/main.go
@@ -116,7 +116,6 @@ func main() {
 	// ctxParams.NUbatch = 512   // Keep default value
 	ctxParams.NSeqMax = 1 // Set max sequences to 1 for simple use case
 	ctxParams.NThreads = int32(*threads)
-	ctxParams.Logits = 1 // true as uint8
 
 	fmt.Printf("Setting context size to: %d\n", *ctx)
 	fmt.Printf("Context params NCtx: %d\n", ctxParams.NCtx)

--- a/examples/simple-chat/main.go
+++ b/examples/simple-chat/main.go
@@ -101,7 +101,6 @@ func main() {
 	// ctxParams.NUbatch = 512   // Keep default value
 	ctxParams.NSeqMax = 1 // Set max sequences to 1 for simple use case
 	ctxParams.NThreads = int32(*threads)
-	ctxParams.Logits = 1 // true as uint8
 
 	fmt.Printf("Setting context size to: %d\n", *ctx)
 	fmt.Printf("Context params NCtx: %d\n", ctxParams.NCtx)

--- a/examples/speculative/main.go
+++ b/examples/speculative/main.go
@@ -132,7 +132,6 @@ func main() {
 	ctxParamsTgt.NCtx = uint32(*ctx)
 	ctxParamsTgt.NThreads = int32(*threads)
 	ctxParamsTgt.NThreadsBatch = int32(*threads)
-	ctxParamsTgt.Logits = 1
 
 	ctxTgt, err := gollama.Init_from_model(modelTgt, ctxParamsTgt)
 	if err != nil {
@@ -156,7 +155,6 @@ func main() {
 	ctxParamsDft.NCtx = uint32(*ctx)
 	ctxParamsDft.NThreads = int32(*threads)
 	ctxParamsDft.NThreadsBatch = int32(*threads)
-	ctxParamsDft.Logits = 1
 
 	ctxDft, err := gollama.Init_from_model(modelDft, ctxParamsDft)
 	if err != nil {

--- a/ffi.go
+++ b/ffi.go
@@ -27,15 +27,16 @@ var (
 			&ffi.TypeUint8,   // use_mlock
 			&ffi.TypeUint8,   // check_tensors
 			&ffi.TypeUint8,   // use_extra_bufts
+			&ffi.TypeUint8,   // no_host
 			nil,
 		}[0],
 	}
 
 	// LlamaContextParams FFI type
+	// Layout MUST match struct llama_context_params in llama.h (b6862).
 	ffiTypeLlamaContextParams = ffi.Type{
 		Type: ffi.Struct,
 		Elements: &[]*ffi.Type{
-			&ffi.TypeUint32,  // seed
 			&ffi.TypeUint32,  // n_ctx
 			&ffi.TypeUint32,  // n_batch
 			&ffi.TypeUint32,  // n_ubatch
@@ -45,6 +46,7 @@ var (
 			&ffi.TypeSint32,  // rope_scaling_type
 			&ffi.TypeSint32,  // pooling_type
 			&ffi.TypeSint32,  // attention_type
+			&ffi.TypeSint32,  // flash_attn_type
 			&ffi.TypeFloat,   // rope_freq_base
 			&ffi.TypeFloat,   // rope_freq_scale
 			&ffi.TypeFloat,   // yarn_ext_factor
@@ -59,11 +61,12 @@ var (
 			&ffi.TypeSint32,  // type_v
 			&ffi.TypePointer, // abort_callback
 			&ffi.TypePointer, // abort_callback_data
-			&ffi.TypeUint8,   // logits
 			&ffi.TypeUint8,   // embeddings
 			&ffi.TypeUint8,   // offload_kqv
-			&ffi.TypeUint8,   // flash_attn
 			&ffi.TypeUint8,   // no_perf
+			&ffi.TypeUint8,   // op_offload
+			&ffi.TypeUint8,   // swa_full
+			&ffi.TypeUint8,   // kv_unified
 			nil,
 		}[0],
 	}

--- a/ffi_test.go
+++ b/ffi_test.go
@@ -98,10 +98,10 @@ func (s *FFISuite) TestFFIContextDefaultParams() {
 		return
 	}
 
-	s.Assert().NotZero(params.Seed, "Seed should not be zero in default params")
 	s.Assert().NotZero(params.NBatch, "NBatch should not be zero in default params")
-	s.T().Logf("FFI Context default params: Seed=%d, NCtx=%d, NBatch=%d, NThreads=%d",
-		params.Seed, params.NCtx, params.NBatch, params.NThreads)
+	s.Assert().NotZero(params.NUbatch, "NUbatch should not be zero in default params")
+	s.T().Logf("FFI Context default params: NCtx=%d, NBatch=%d, NUbatch=%d, NSeqMax=%d, NThreads=%d, FlashAttnType=%d",
+		params.NCtx, params.NBatch, params.NUbatch, params.NSeqMax, params.NThreads, params.FlashAttnType)
 }
 
 // Tests FFI-based sampler chain parameter retrieval

--- a/gollama.go
+++ b/gollama.go
@@ -190,6 +190,14 @@ const (
 	LLAMA_ATTENTION_TYPE_NON_CAUSAL LlamaAttentionType = 1
 )
 
+type LlamaFlashAttnType int32
+
+const (
+	LLAMA_FLASH_ATTN_TYPE_AUTO     LlamaFlashAttnType = -1
+	LLAMA_FLASH_ATTN_TYPE_DISABLED LlamaFlashAttnType = 0
+	LLAMA_FLASH_ATTN_TYPE_ENABLED  LlamaFlashAttnType = 1
+)
+
 type LlamaSplitMode int32
 
 const (
@@ -282,11 +290,15 @@ type LlamaModelParams struct {
 	UseMlock                 uint8          // force system to keep model in RAM (bool as uint8)
 	CheckTensors             uint8          // validate model tensor data (bool as uint8)
 	UseExtraBufts            uint8          // use extra buffer types (bool as uint8)
+	NoHost                   uint8          // bypass host buffer allowing extra buffers to be used (bool as uint8)
 }
 
 // Context parameters
+//
+// Layout MUST match struct llama_context_params in llama.h for the bundled
+// llama.cpp build (b6862). The struct is passed/returned BY VALUE across the
+// FFI boundary, so any drift silently lands fields on the wrong C offsets.
 type LlamaContextParams struct {
-	Seed              uint32               // RNG seed, -1 for random
 	NCtx              uint32               // text context, 0 = from model
 	NBatch            uint32               // logical maximum batch size
 	NUbatch           uint32               // physical maximum batch size
@@ -296,6 +308,7 @@ type LlamaContextParams struct {
 	RopeScalingType   LlamaRopeScalingType // RoPE scaling type
 	PoolingType       LlamaPoolingType     // pooling type for embeddings
 	AttentionType     LlamaAttentionType   // attention type
+	FlashAttnType     LlamaFlashAttnType   // when to enable Flash Attention
 	RopeFreqBase      float32              // RoPE base frequency
 	RopeFreqScale     float32              // RoPE frequency scaling factor
 	YarnExtFactor     float32              // YaRN extrapolation mix factor
@@ -303,18 +316,19 @@ type LlamaContextParams struct {
 	YarnBetaFast      float32              // YaRN low correction dim
 	YarnBetaSlow      float32              // YaRN high correction dim
 	YarnOrigCtx       uint32               // YaRN original context size
-	DefragThold       float32              // defragment the KV cache if holes/size > thold
+	DefragThold       float32              // [DEPRECATED] defragment the KV cache if holes/size > thold
 	CbEval            uintptr              // evaluation callback
 	CbEvalUserData    uintptr              // user data for evaluation callback
 	TypeK             int32                // data type for K cache
 	TypeV             int32                // data type for V cache
 	AbortCallback     uintptr              // abort callback
 	AbortCallbackData uintptr              // user data for abort callback
-	Logits            uint8                // whether to compute and return logits (bool as uint8)
-	Embeddings        uint8                // whether to compute and return embeddings (bool as uint8)
-	Offload_kqv       uint8                // whether to offload K, Q, V to GPU (bool as uint8)
-	FlashAttn         uint8                // whether to use flash attention (bool as uint8)
-	NoPerf            uint8                // whether to measure performance (bool as uint8)
+	Embeddings        uint8                // whether to extract embeddings, together with logits (bool as uint8)
+	Offload_kqv       uint8                // whether to offload KQV ops (incl. KV cache) to GPU (bool as uint8)
+	NoPerf            uint8                // whether to skip performance timings (bool as uint8)
+	OpOffload         uint8                // offload host tensor operations to device (bool as uint8)
+	SwaFull           uint8                // use full-size SWA cache (bool as uint8)
+	KvUnified         uint8                // use a unified KV buffer across input sequences (bool as uint8)
 }
 
 // Model quantize parameters
@@ -929,7 +943,6 @@ func Context_default_params() LlamaContextParams {
 
 	// Last resort: return hardcoded defaults
 	return LlamaContextParams{
-		Seed:            LLAMA_DEFAULT_SEED,
 		NCtx:            0, // Auto-detect from model
 		NBatch:          2048,
 		NUbatch:         512,
@@ -939,12 +952,14 @@ func Context_default_params() LlamaContextParams {
 		RopeScalingType: LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED,
 		PoolingType:     LLAMA_POOLING_TYPE_UNSPECIFIED,
 		AttentionType:   LLAMA_ATTENTION_TYPE_CAUSAL,
+		FlashAttnType:   LLAMA_FLASH_ATTN_TYPE_AUTO,
 		DefragThold:     -1.0, // Disabled by default
-		Logits:          0,    // Disabled by default
 		Embeddings:      0,    // Disabled by default
 		Offload_kqv:     1,    // Enable by default
-		FlashAttn:       0,    // Disabled by default
 		NoPerf:          0,    // Enable performance measurement by default
+		OpOffload:       1,    // Enable by default (matches llama.cpp)
+		SwaFull:         1,    // Enable by default (matches llama.cpp)
+		KvUnified:       0,    // Disabled by default (matches llama.cpp)
 	}
 }
 
@@ -1507,7 +1522,6 @@ func ContextDefaultParams() LlamaContextParams {
 	}
 	// Return default values for non-Darwin platforms - blocks ROADMAP "wait for purego struct support"
 	return LlamaContextParams{
-		Seed:            LLAMA_DEFAULT_SEED,
 		NCtx:            0, // 0 = from model
 		NBatch:          2048,
 		NUbatch:         512,
@@ -1517,6 +1531,7 @@ func ContextDefaultParams() LlamaContextParams {
 		RopeScalingType: LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED,
 		PoolingType:     LLAMA_POOLING_TYPE_UNSPECIFIED,
 		AttentionType:   LLAMA_ATTENTION_TYPE_CAUSAL,
+		FlashAttnType:   LLAMA_FLASH_ATTN_TYPE_AUTO,
 		RopeFreqBase:    0.0, // 0.0 = from model
 		RopeFreqScale:   0.0, // 0.0 = from model
 		YarnExtFactor:   -1.0,
@@ -1527,11 +1542,12 @@ func ContextDefaultParams() LlamaContextParams {
 		DefragThold:     -1.0,
 		TypeK:           -1,
 		TypeV:           -1,
-		Logits:          0,
 		Embeddings:      0,
 		Offload_kqv:     1,
-		FlashAttn:       0,
 		NoPerf:          0,
+		OpOffload:       1,
+		SwaFull:         1,
+		KvUnified:       0,
 	}
 }
 


### PR DESCRIPTION
## Problem

`LlamaContextParams` matches a much older llama.cpp than the bundled b6862 libraries. By coincidence both layouts are 120 bytes, so nothing crashes — but every field in the first 40 bytes (and the bool tail) silently lands on the **wrong C struct member**, on every platform and both FFI paths (purego struct registration on darwin, libffi descriptors elsewhere — `ffi.go` encodes the same stale layout).

| Go field (old) | actual C field it landed on (b6862) |
|---|---|
| `Seed` | `n_ctx` |
| `NCtx` | `n_batch` |
| `NBatch` | `n_ubatch` |
| `NUbatch` | `n_seq_max` |
| `NSeqMax` | `n_threads` |
| `NThreads` | `n_threads_batch` |
| `NThreadsBatch` | `rope_scaling_type` |
| `RopeScalingType` | `pooling_type` |
| `PoolingType` | `attention_type` |
| `AttentionType` | `flash_attn_type` |
| *(aligned again from `rope_freq_base` through `abort_callback_data`)* | |
| `Logits` | `embeddings` |
| `Embeddings` | `offload_kqv` |
| `Offload_kqv` | `no_perf` |
| `FlashAttn` | `op_offload` |
| `NoPerf` | `swa_full` |

Observed symptoms (darwin-amd64, official b6862 dylib):
- `cp.NUbatch = 512` → `llama_init_from_model: failed to initialize the context: n_seq_max must be <= 256`
- `cp.Embeddings = 1` actually enabled `offload_kqv`; real `embeddings` stayed `false` → `llama_get_embeddings*` returns NULL
- `Context_default_params()` reported `NCtx=2048` (that's `n_batch`'s default read through the wrong offset)

## Fix
- `LlamaContextParams`: drop `Seed` (removed from `llama_context_params` upstream long ago; `LLAMA_DEFAULT_SEED` kept for samplers), add `FlashAttnType` (`LLAMA_FLASH_ATTN_TYPE_{AUTO,DISABLED,ENABLED}`), replace the bool tail with b6862's `{embeddings, offload_kqv, no_perf, op_offload, swa_full, kv_unified}`.
- `LlamaModelParams`: add trailing `NoHost` (b6862).
- `ffi.go`: both libffi struct descriptors updated to the same layout.
- Hardcoded default fallbacks updated; new fields use llama.cpp's defaults.
- Examples: drop obsolete `ctxParams.Logits = 1` (no context-level logits flag in b6862; per-token logits via `batch.logits`).
- `ffi_test`: assert on real fields instead of `Seed` (that assertion only passed because `Seed` was reading `n_ctx`).

## Verification (darwin-amd64, official b6862 dylib)
With this patch, through the public API only:
```
defaults via gollama API: n_ctx=512 n_batch=2048 n_ubatch=512 n_seq_max=1 flash_attn_type=-1   ← correct llama.cpp defaults, correct fields
Init_from_model with mutated NCtx/NBatch/NUbatch/Embeddings/PoolingType → context created
Tokenize + Encode + Get_embeddings_ith → real 768-dim embedding (nomic-embed-text-v1.5 Q8_0), L2≈24.4
```

## Note for darwin-amd64
Unrelated to this PR but adjacent: with the pinned purego v0.9.1, `RegisterFunc(llama_init_from_model)` panics with `too many arguments` on darwin-amd64 (the 120-byte by-value struct exceeds purego's stack-slot budget). Fixed upstream in purego via ebitengine/purego#425 (first available in v0.11.0-alpha.3). Happy to send that bump as a separate PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)